### PR TITLE
Fix rcfile path, needs / to expand properly

### DIFF
--- a/pynux/tests/test_utils.py
+++ b/pynux/tests/test_utils.py
@@ -3,6 +3,7 @@ from pynux import utils
 import json
 import sys
 import re
+import os
 
 import unittest
 
@@ -39,6 +40,14 @@ class TestNuxeoREST(unittest.TestCase):
         assert(self.nx.children("asset-library"))
         assert(self.nx.get_metadata(uid= self.nx.get_uid("asset-library")))
         assert(self.nx.get_metadata(path="asset-library"))
+
+class TestConfigFile(unittest.TestCase):
+    '''Had a problem with the default config path. Check it here'''
+    def testRCFILE(self):
+        rcfile = utils._rcfile_
+        full_path = os.path.expanduser(rcfile)
+        # then expanded path should be different
+        self.assertNotEqual(full_path, utils._rcfile_)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pynux/utils.py
+++ b/pynux/utils.py
@@ -22,7 +22,7 @@ import io
 import argparse
 
 _loglevel_ = 'ERROR'
-_rcfile_ = '~.pynuxrc'
+_rcfile_ = '~/.pynuxrc'
 _version_ = '0.0.0'
 
 class Nuxeo:


### PR DESCRIPTION
default _rcfile_ should be "~/.pynuxrc" not "~.pynuxrc". os.path.expanduser doesn't work on the second variation.