### PR TITLE
more options for nxls

### DIFF
--- a/pynux/nxls.py
+++ b/pynux/nxls.py
@@ -15,7 +15,10 @@ def main(argv=None):
     parser.add_argument('--outdir', 
         help="directory to hold application/json+nxentity .json files",
         type=utf8_arg)
-    parser.add_argument('-r', '--recursive', dest='recursive', action='store_true')
+    parser.add_argument('-r', '--recursive', action='store_true')
+    show = parser.add_mutually_exclusive_group(required=False)
+    show.add_argument('--show-only-uid', action='store_true')
+    show.add_argument('--show-only-path', action='store_true')
     utils.get_common_options(parser)
     if argv is None:
         argv = parser.parse_args()
@@ -31,6 +34,12 @@ def main(argv=None):
         # Expand user- and relative-paths
         outdir = os.path.abspath(os.path.expanduser(argv.outdir))
         nx.copy_metadata_to_local(documents, outdir)
+    elif argv.show_only_path == True:
+        for document in documents:
+            print(document['path'])
+    elif argv.show_only_uid == True:
+        for document in documents:
+            print(document['uid'])
     else:
         nx.print_document_summary(documents)
 

--- a/pynux/nxls.py
+++ b/pynux/nxls.py
@@ -11,11 +11,17 @@ from pynux.utils import utf8_arg
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description='nuxeo metadata via REST API')
-    parser.add_argument('path', nargs=1, help="nuxeo document path", type=utf8_arg)
+    parser.add_argument('path', nargs=1, help='nuxeo document path', type=utf8_arg)
     parser.add_argument('--outdir', 
         help="directory to hold application/json+nxentity .json files",
         type=utf8_arg)
-    parser.add_argument('-r', '--recursive', action='store_true')
+    rstyle = parser.add_mutually_exclusive_group(required=False)
+    rstyle.add_argument('--recursive-folders',
+                        help='recursively list project folders/Organzation',
+                        action='store_true')
+    rstyle.add_argument('--recursive-objects',
+                        help='recursively list objects',
+                        action='store_true')
     show = parser.add_mutually_exclusive_group(required=False)
     show.add_argument('--show-only-uid', action='store_true')
     show.add_argument('--show-only-path', action='store_true')
@@ -25,8 +31,10 @@ def main(argv=None):
 
     nx = utils.Nuxeo(rcfile=argv.rcfile, loglevel=argv.loglevel.upper())
 
-    if argv.recursive:
-        documents = nx.recursive_children(argv.path[0])
+    if argv.recursive_folders:
+        documents = nx.recursive_project_folders(argv.path[0])
+    elif argv.recursive_objects:
+        documents = nx.recursive_objects(argv.path[0])
     else:
         documents = nx.children(argv.path[0])
 

--- a/pynux/nxls.py
+++ b/pynux/nxls.py
@@ -15,12 +15,17 @@ def main(argv=None):
     parser.add_argument('--outdir', 
         help="directory to hold application/json+nxentity .json files",
         type=utf8_arg)
+    parser.add_argument('-r', '--recursive', dest='recursive', action='store_true')
     utils.get_common_options(parser)
     if argv is None:
         argv = parser.parse_args()
 
     nx = utils.Nuxeo(rcfile=argv.rcfile, loglevel=argv.loglevel.upper())
-    documents = nx.children(argv.path[0])
+
+    if argv.recursive:
+        documents = nx.recursive_children(argv.path[0])
+    else:
+        documents = nx.children(argv.path[0])
 
     if argv.outdir:
         # Expand user- and relative-paths
@@ -35,7 +40,7 @@ if __name__ == "__main__":
     sys.exit(main())
 
 """
-Copyright © 2014, Regents of the University of California
+Copyright © 2016, Regents of the University of California
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/pynux/utils.py
+++ b/pynux/utils.py
@@ -28,8 +28,14 @@ sys.stdout = UTF8Writer(sys.stdout)
 _loglevel_ = 'ERROR'
 _version_ = '0.0.3'
 
-RECURSIVE_NXQL = """SELECT * FROM Document
-WHERE ecm:parentId = '{}' AND ecm:currentLifeCycleState != 'deleted'
+RECURSIVE_NXQL_PROJECT_FOLDER = """SELECT *
+FROM Organization
+WHERE ecm:path STARTSWITH '{}' AND ecm:currentLifeCycleState != 'deleted'
+ORDER BY ecm:pos"""
+
+RECURSIVE_NXQL_OBJECT = """SELECT *
+FROM SampleCustomPicture, CustomFile, CustomVideo, CustomAudio
+WHERE ecm:path STARTSWITH '{}' AND ecm:currentLifeCycleState != 'deleted'
 ORDER BY ecm:pos"""
 
 
@@ -194,8 +200,15 @@ base = http://localhost:8080/nuxeo/site/fileImporter
         self.logger.debug(url)
         return self._get_iter(url, params)
 
-    def recursive_children(self, path):
-        return self.nxql(RECURSIVE_NXQL.format(self.get_uid(path)))
+    def recursive_project_folders(self, path):
+        nxql = RECURSIVE_NXQL_PROJECT_FOLDER.format(path)
+        self.logger.debug(nxql)
+        return self.nxql(nxql)
+
+    def recursive_objects(self, path):
+        nxql = RECURSIVE_NXQL_OBJECT.format(path)
+        self.logger.debug(nxql)
+        return self.nxql(nxql)
 
     def get_uid(self, path):
         """look up uid from the path
@@ -263,7 +276,7 @@ base = http://localhost:8080/nuxeo/site/fileImporter
 
     def print_document_summary(self, documents):
         for document in documents:
-            print '{0}\t{1}'.format(document['uid'], document['path'])
+            print '\t'.join([document['uid'], document['type'], document['path']])
 
     def copy_metadata_to_local(self, documents, local):
         for document in documents:


### PR DESCRIPTION
adds to `nxls`

```
usage: nxls.py [-h] [--outdir OUTDIR]
               [--recursive-folders | --recursive-objects]
               [--show-only-uid | --show-only-path] [--loglevel LOGLEVEL]
               [--rcfile RCFILE]
               path

nuxeo metadata via REST API

positional arguments:
  path                 nuxeo document path

optional arguments:
  -h, --help           show this help message and exit
  --outdir OUTDIR      directory to hold application/json+nxentity .json files
  --recursive-folders  recursively list project folders/Organzation
  --recursive-objects  recursively list objects
  --show-only-uid
  --show-only-path

common options for pynux commands:
  --loglevel LOGLEVEL  CRITICAL ERROR WARNING INFO DEBUG NOTSET, default is
                       ERROR
  --rcfile RCFILE      path to ConfigParser compatible ini file
```