### PR TITLE
nxid: fix date and type metadata issues, add "location" argument

### DIFF
--- a/pynux/nxid.py
+++ b/pynux/nxid.py
@@ -197,7 +197,7 @@ def item_erc_dict(item, owner=None, status=None, publisher=None, location=None):
     title = p.get('dc:title', '(:unav)')
     if title is None:
         title = '(:unav)'
-    type_ = p.get('dc:type', '(:unav)')
+    type_ = p.get('ucldc_schema:type', '(:unav)')
     if type_ is None:
         type_ = '(:unav)'
     # repeating creator

--- a/pynux/nxid.py
+++ b/pynux/nxid.py
@@ -220,6 +220,7 @@ def item_erc_dict(item, owner=None, status=None, publisher=None, location=None):
         'dc.title': title,
         'dc.creator': creator,
         'dc.type': type_,
+        'dc.date': date,
     }
 
     if owner:

--- a/pynux/nxid.py
+++ b/pynux/nxid.py
@@ -60,6 +60,8 @@ def main(argv=None):
         '--status', help='set as _status for EZID (public|reserved|unavailable)', type=utf8_arg)
     conf_group.add_argument(
         '--publisher', help='set as dc.publisher for EZID', type=utf8_arg)
+    conf_group.add_argument(
+        '--location', help='set location URL prefix for EZID', type=utf8_arg)
 
     utils.get_common_options(parser)
     if argv is None:
@@ -107,6 +109,7 @@ AND ecm:pos is NULL'''.format(argv.path[0]))
             owner=argv.owner,            # _owner
             status=argv.status,          # _status
             publisher=argv.publisher,    # dc.publisher
+            location=argv.location       # _target
         )
 
         if argv.show_erc:
@@ -187,7 +190,7 @@ def update_nuxeo(item, nx, ark):
     nx.update_nuxeo_properties(update_doc, uid=item['uid'])
 
 
-def item_erc_dict(item, owner=None, status=None, publisher=None):
+def item_erc_dict(item, owner=None, status=None, publisher=None, location=None):
     ''' create erc dict for item '''
     # metadata mapping from nuxeo to ERC
     p = item['properties']
@@ -209,6 +212,8 @@ def item_erc_dict(item, owner=None, status=None, publisher=None):
         date = date_list[0].get('date')
     else:
         date = '(:unav)'
+    #set identifier variable again for use in setting _target
+    identifier = p.get('ucldc_schema:identifier')
 
     ezdata = {
         '_profile': 'dc',
@@ -223,6 +228,8 @@ def item_erc_dict(item, owner=None, status=None, publisher=None):
         ezdata.update({'_status': status})
     if publisher:
         ezdata.update({'dc.publisher': publisher})
+    if location:
+    	ezdata.update({'_target': location + identifier})
 
     return ezdata
 


### PR DESCRIPTION
I fixed two separate typos that were preventing the Nuxeo date and type fields from being posted to EZID.

I also added the argument "location" to allow updating the "Location (URL)" field in EZID. Passing the non-ARK portion of the desired location URL (like `--location https://calisphere.org/item/`), sets "Location URL" as, for example, "https://calisphere.org/item/ark:/86086/n2zp45j9/" rather than the default "https://ezid.cdlib.org/id/ark:/86086/n2zp45j9". 