### PR TITLE
Update Auth Token in README to use correct base

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ user = Administrator
 password = Administrator
 
 [rest_api]
-base = http://localhost:8080/nuxeo/site/api/v1
+base = https://nuxeo.cdlib.org/Nuxeo/site/api/v1 
 X-NXDocumentProperties = dublincore
 # for developers on the UCLDC project; use
 # X-NXDocumentProperties = dublincore,ucldc_schema,picture


### PR DESCRIPTION
This is my very first pull request for pynux so apologies if I'm missing something!

The "base" in the .pynuxrc example in Authentication section of README does not work for me as configured (testing with `$ nxls /`. If I use the "base" that is indicated in the example at https://gist.github.com/tingletech/011059ca25d72104633d#file-cdl_nuxeo_config-md then `$ nxls /` works as expected. I updated the .pynuxrc example here to use the same "base" as the one linked above. 